### PR TITLE
Made it possible to call UseMorphTarget on IMeshBuilder<TMaterial>

### DIFF
--- a/src/SharpGLTF.Toolkit/Geometry/MeshBuilder.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/MeshBuilder.cs
@@ -130,6 +130,11 @@ namespace SharpGLTF.Geometry
             return new MorphTargetBuilder<TMaterial, TvG, TvS, TvM>(this, index);
         }
 
+        IMorphTargetBuilder IMeshBuilder<TMaterial>.UseMorphTarget(int index)
+        {
+            return UseMorphTarget(index);
+        }
+
         private PrimitiveBuilder<TMaterial, TvG, TvM, TvS> _UsePrimitive((TMaterial Material, int PrimType) key)
         {
             if (!_Primitives.TryGetValue(key, out PrimitiveBuilder<TMaterial, TvG, TvM, TvS> primitive))

--- a/src/SharpGLTF.Toolkit/Geometry/MeshBuilder.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/MeshBuilder.cs
@@ -125,9 +125,9 @@ namespace SharpGLTF.Geometry
 
         #region API
 
-        public MorphTargetBuilder<TMaterial, TvG, TvS, TvM> UseMorphTarget(int index)
+        public MorphTargetBuilder UseMorphTarget(int index)
         {
-            return new MorphTargetBuilder<TMaterial, TvG, TvS, TvM>(this, index);
+            return new MorphTargetBuilder(this.Primitives.Select(p => ((IPrimitiveBuilder)p, (IReadOnlyList<IVertexBuilder>)p.Vertices)), index);
         }
 
         private PrimitiveBuilder<TMaterial, TvG, TvM, TvS> _UsePrimitive((TMaterial Material, int PrimType) key)

--- a/src/SharpGLTF.Toolkit/Geometry/MeshBuilder.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/MeshBuilder.cs
@@ -125,9 +125,9 @@ namespace SharpGLTF.Geometry
 
         #region API
 
-        public MorphTargetBuilder UseMorphTarget(int index)
+        public MorphTargetBuilder<TMaterial, TvG, TvS, TvM> UseMorphTarget(int index)
         {
-            return new MorphTargetBuilder(this.Primitives.Select(p => ((IPrimitiveBuilder)p, (IReadOnlyList<IVertexBuilder>)p.Vertices)), index);
+            return new MorphTargetBuilder<TMaterial, TvG, TvS, TvM>(this, index);
         }
 
         private PrimitiveBuilder<TMaterial, TvG, TvM, TvS> _UsePrimitive((TMaterial Material, int PrimType) key)

--- a/src/SharpGLTF.Toolkit/Geometry/MeshBuilderToolkit.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/MeshBuilderToolkit.cs
@@ -16,6 +16,7 @@ namespace SharpGLTF.Geometry
 
         IReadOnlyCollection<IPrimitiveReader<TMaterial>> Primitives { get; }
 
+        MorphTargetBuilder UseMorphTarget(int index);
         IPrimitiveBuilder UsePrimitive(TMaterial material, int primitiveVertexCount = 3);
 
         IMeshBuilder<TMaterial> Clone(Func<TMaterial, TMaterial> materialCloneCallback = null);

--- a/src/SharpGLTF.Toolkit/Geometry/MeshBuilderToolkit.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/MeshBuilderToolkit.cs
@@ -18,6 +18,8 @@ namespace SharpGLTF.Geometry
 
         IPrimitiveBuilder UsePrimitive(TMaterial material, int primitiveVertexCount = 3);
 
+        IMorphTargetBuilder UseMorphTarget(int index);
+
         IMeshBuilder<TMaterial> Clone(Func<TMaterial, TMaterial> materialCloneCallback = null);
 
         void Validate();

--- a/src/SharpGLTF.Toolkit/Geometry/MeshBuilderToolkit.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/MeshBuilderToolkit.cs
@@ -16,7 +16,6 @@ namespace SharpGLTF.Geometry
 
         IReadOnlyCollection<IPrimitiveReader<TMaterial>> Primitives { get; }
 
-        MorphTargetBuilder UseMorphTarget(int index);
         IPrimitiveBuilder UsePrimitive(TMaterial material, int primitiveVertexCount = 3);
 
         IMeshBuilder<TMaterial> Clone(Func<TMaterial, TMaterial> materialCloneCallback = null);

--- a/src/SharpGLTF.Toolkit/Geometry/MorphTargetBuilder.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/MorphTargetBuilder.cs
@@ -153,10 +153,21 @@ namespace SharpGLTF.Geometry
         #endregion
     }
 
+    public interface IMorphTargetBuilder
+    {
+        IReadOnlyCollection<Vector3> Positions { get; }
+        IReadOnlyCollection<IVertexGeometry> Vertices { get; }
+        IReadOnlyList<IVertexGeometry> GetVertices(Vector3 position);
+
+        void SetVertex(IVertexGeometry meshVertex, IVertexGeometry morphVertex);
+        void SetVertexDelta(Vector3 key, VertexGeometryDelta delta);
+        void SetVertexDelta(IVertexGeometry meshVertex, VertexGeometryDelta delta);
+    }
+
     /// <summary>
     /// Utility class to edit the Morph targets of a mesh.
     /// </summary>
-    public sealed class MorphTargetBuilder<TMaterial, TvG, TvS, TvM>
+    public sealed class MorphTargetBuilder<TMaterial, TvG, TvS, TvM> : IMorphTargetBuilder
             where TvG : struct, IVertexGeometry
             where TvM : struct, IVertexMaterial
             where TvS : struct, IVertexSkinning
@@ -210,6 +221,8 @@ namespace SharpGLTF.Geometry
 
         public IReadOnlyCollection<TvG> Vertices => _Vertices.Keys;
 
+        IReadOnlyCollection<IVertexGeometry> IMorphTargetBuilder.Vertices => (IReadOnlyList<IVertexGeometry>)(IReadOnlyCollection<TvG>)_Vertices.Keys;
+
         #endregion
 
         #region API
@@ -217,6 +230,11 @@ namespace SharpGLTF.Geometry
         public IReadOnlyList<TvG> GetVertices(Vector3 position)
         {
             return _Positions.TryGetValue(position, out List<TvG> geos) ? (IReadOnlyList<TvG>)geos : Array.Empty<TvG>();
+        }
+
+        IReadOnlyList<IVertexGeometry> IMorphTargetBuilder.GetVertices(Vector3 position)
+        {
+            return _Positions.TryGetValue(position, out List<TvG> geos) ? (IReadOnlyList<IVertexGeometry>)geos : Array.Empty<IVertexGeometry>();
         }
 
         public void SetVertexDelta(Vector3 key, VertexGeometryDelta delta)
@@ -240,6 +258,11 @@ namespace SharpGLTF.Geometry
             }
         }
 
+        void IMorphTargetBuilder.SetVertex(IVertexGeometry meshVertex, IVertexGeometry morphVertex)
+        {
+            SetVertex(meshVertex.ConvertToGeometry<TvG>(), morphVertex.ConvertToGeometry<TvG>());
+        }
+
         public void SetVertexDelta(TvG meshVertex, VertexGeometryDelta delta)
         {
             if (_Vertices.TryGetValue(meshVertex, out List<(PrimitiveBuilder<TMaterial, TvG, TvM, TvS>, int)> val))
@@ -251,6 +274,11 @@ namespace SharpGLTF.Geometry
                         .SetVertexDelta(entry.Item2, delta);
                 }
             }
+        }
+
+        void IMorphTargetBuilder.SetVertexDelta(IVertexGeometry meshVertex, VertexGeometryDelta delta)
+        {
+            SetVertexDelta(meshVertex.ConvertToGeometry<TvG>(), delta);
         }
 
         #endregion

--- a/src/SharpGLTF.Toolkit/Geometry/PrimitiveBuilder.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/PrimitiveBuilder.cs
@@ -71,7 +71,6 @@ namespace SharpGLTF.Geometry
         /// </summary>
         Type VertexType { get; }
 
-        void SetVertex(int morphTargetIndex, int vertexIndex, IVertexGeometry morphVertex);
         void SetVertexDelta(int morphTargetIndex, int vertexIndex, VertexGeometryDelta delta);
 
         int AddPoint(IVertexBuilder a);
@@ -135,7 +134,7 @@ namespace SharpGLTF.Geometry
 
             foreach (var otherMT in other._MorphTargets)
             {
-                var thisMT = new PrimitiveMorphTargetBuilder(idx => this._Vertices[idx].Geometry, otherMT);
+                var thisMT = new PrimitiveMorphTargetBuilder<TvG>(idx => this._Vertices[idx].Geometry, otherMT);
                 this._MorphTargets.Add(otherMT);
             }
         }
@@ -152,7 +151,7 @@ namespace SharpGLTF.Geometry
 
         private readonly VertexListWrapper _Vertices = new VertexListWrapper();
 
-        private readonly List<PrimitiveMorphTargetBuilder> _MorphTargets = new List<PrimitiveMorphTargetBuilder>();
+        private readonly List<PrimitiveMorphTargetBuilder<TvG>> _MorphTargets = new List<PrimitiveMorphTargetBuilder<TvG>>();
 
         #endregion
 
@@ -190,9 +189,9 @@ namespace SharpGLTF.Geometry
 
         #region API - morph targets
 
-        internal PrimitiveMorphTargetBuilder _UseMorphTarget(int morphTargetIndex)
+        internal PrimitiveMorphTargetBuilder<TvG> _UseMorphTarget(int morphTargetIndex)
         {
-            while (this._MorphTargets.Count <= morphTargetIndex) this._MorphTargets.Add(new PrimitiveMorphTargetBuilder(idx => _Vertices[idx].Geometry));
+            while (this._MorphTargets.Count <= morphTargetIndex) this._MorphTargets.Add(new PrimitiveMorphTargetBuilder<TvG>(idx => _Vertices[idx].Geometry));
 
             return this._MorphTargets[morphTargetIndex];
         }
@@ -229,11 +228,6 @@ namespace SharpGLTF.Geometry
         protected int UseVertex(VertexBuilder<TvG, TvM, TvS> vertex)
         {
             return _Vertices.Use(vertex);
-        }
-
-        void IPrimitiveBuilder.SetVertex(int morphTargetIndex, int vertexIndex, IVertexGeometry morphVertex)
-        {
-            _UseMorphTarget(morphTargetIndex).SetVertex(vertexIndex, morphVertex);
         }
 
         void IPrimitiveBuilder.SetVertexDelta(int morphTargetIndex, int vertexIndex, VertexGeometryDelta delta)
@@ -317,7 +311,7 @@ namespace SharpGLTF.Geometry
         {
             _Vertices.TransformVertices(vertexTransformFunc);
 
-            IVertexGeometry geoFunc(IVertexGeometry g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g.ConvertToGeometry<TvG>(), default, default(TvS))).Geometry;
+            TvG geoFunc(TvG g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g, default, default(TvS))).Geometry;
 
             foreach (var mt in _MorphTargets) mt.TransformVertices(geoFunc);
         }
@@ -386,7 +380,7 @@ namespace SharpGLTF.Geometry
                 }
             }
 
-            IVertexGeometry geoFunc(IVertexGeometry g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g.ConvertToGeometry<TvG>(), default, default(TvS))).Geometry;
+            TvG geoFunc(TvG g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g, default, default(TvS))).Geometry;
 
             for (int i = 0; i < primitive._MorphTargets.Count; ++i)
             {

--- a/src/SharpGLTF.Toolkit/Geometry/PrimitiveBuilder.cs
+++ b/src/SharpGLTF.Toolkit/Geometry/PrimitiveBuilder.cs
@@ -71,6 +71,7 @@ namespace SharpGLTF.Geometry
         /// </summary>
         Type VertexType { get; }
 
+        void SetVertex(int morphTargetIndex, int vertexIndex, IVertexGeometry morphVertex);
         void SetVertexDelta(int morphTargetIndex, int vertexIndex, VertexGeometryDelta delta);
 
         int AddPoint(IVertexBuilder a);
@@ -134,7 +135,7 @@ namespace SharpGLTF.Geometry
 
             foreach (var otherMT in other._MorphTargets)
             {
-                var thisMT = new PrimitiveMorphTargetBuilder<TvG>(idx => this._Vertices[idx].Geometry, otherMT);
+                var thisMT = new PrimitiveMorphTargetBuilder(idx => this._Vertices[idx].Geometry, otherMT);
                 this._MorphTargets.Add(otherMT);
             }
         }
@@ -151,7 +152,7 @@ namespace SharpGLTF.Geometry
 
         private readonly VertexListWrapper _Vertices = new VertexListWrapper();
 
-        private readonly List<PrimitiveMorphTargetBuilder<TvG>> _MorphTargets = new List<PrimitiveMorphTargetBuilder<TvG>>();
+        private readonly List<PrimitiveMorphTargetBuilder> _MorphTargets = new List<PrimitiveMorphTargetBuilder>();
 
         #endregion
 
@@ -189,9 +190,9 @@ namespace SharpGLTF.Geometry
 
         #region API - morph targets
 
-        internal PrimitiveMorphTargetBuilder<TvG> _UseMorphTarget(int morphTargetIndex)
+        internal PrimitiveMorphTargetBuilder _UseMorphTarget(int morphTargetIndex)
         {
-            while (this._MorphTargets.Count <= morphTargetIndex) this._MorphTargets.Add(new PrimitiveMorphTargetBuilder<TvG>(idx => _Vertices[idx].Geometry));
+            while (this._MorphTargets.Count <= morphTargetIndex) this._MorphTargets.Add(new PrimitiveMorphTargetBuilder(idx => _Vertices[idx].Geometry));
 
             return this._MorphTargets[morphTargetIndex];
         }
@@ -228,6 +229,11 @@ namespace SharpGLTF.Geometry
         protected int UseVertex(VertexBuilder<TvG, TvM, TvS> vertex)
         {
             return _Vertices.Use(vertex);
+        }
+
+        void IPrimitiveBuilder.SetVertex(int morphTargetIndex, int vertexIndex, IVertexGeometry morphVertex)
+        {
+            _UseMorphTarget(morphTargetIndex).SetVertex(vertexIndex, morphVertex);
         }
 
         void IPrimitiveBuilder.SetVertexDelta(int morphTargetIndex, int vertexIndex, VertexGeometryDelta delta)
@@ -311,7 +317,7 @@ namespace SharpGLTF.Geometry
         {
             _Vertices.TransformVertices(vertexTransformFunc);
 
-            TvG geoFunc(TvG g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g, default, default(TvS))).Geometry;
+            IVertexGeometry geoFunc(IVertexGeometry g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g.ConvertToGeometry<TvG>(), default, default(TvS))).Geometry;
 
             foreach (var mt in _MorphTargets) mt.TransformVertices(geoFunc);
         }
@@ -380,7 +386,7 @@ namespace SharpGLTF.Geometry
                 }
             }
 
-            TvG geoFunc(TvG g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g, default, default(TvS))).Geometry;
+            IVertexGeometry geoFunc(IVertexGeometry g) => vertexTransformFunc(new VertexBuilder<TvG, TvM, TvS>(g.ConvertToGeometry<TvG>(), default, default(TvS))).Geometry;
 
             for (int i = 0; i < primitive._MorphTargets.Count; ++i)
             {


### PR DESCRIPTION
I made these changes because I had an IMeshBuilder<> variable that couldn't call UseMorphTarget, and I didn't see a valid reason for why this shouldn't be possible.
```csharp
IMeshBuilder<MaterialBuilder> mb = CreateMeshBuilder();
var pb = mb.UsePrimitive(material); // This worked fine
var mt = mb.UseMorphTarget(0); // This didn't work, but does with this pull request
```
Feel free to reject/close this pull request if you have a better way to do it.