### PR TITLE
Small optimizations to Animation Channel creation

### DIFF
--- a/src/SharpGLTF.Core/Schema2/gltf.Buffer.cs
+++ b/src/SharpGLTF.Core/Schema2/gltf.Buffer.cs
@@ -177,11 +177,26 @@ namespace SharpGLTF.Schema2
         /// <returns>A <see cref="Buffer"/> instance.</returns>
         public Buffer UseBuffer(Byte[] content)
         {
+            return UseBuffer(content, true);
+        }
+
+        /// <summary>
+        /// Creates or reuses a <see cref="Buffer"/> instance
+        /// at <see cref="ModelRoot.LogicalBuffers"/>.
+        /// </summary>
+        /// <param name="content">the byte array to be wrapped as a buffer</param>
+        /// <param name="reuse">whether the method should try to reuse an already existing buffer</param>
+        /// <returns>A <see cref="Buffer"/> instance.</returns>
+        public Buffer UseBuffer(Byte[] content, bool reuse)
+        {
             Guard.IsFalse(content == null, nameof(content));
 
-            foreach (var b in this.LogicalBuffers)
+            if (reuse)
             {
-                if (b.Content == content) return b;
+                foreach (var b in this.LogicalBuffers)
+                {
+                    if (b.Content == content) return b;
+                }
             }
 
             var buffer = new Buffer(content);

--- a/src/SharpGLTF.Core/Schema2/gltf.BufferView.cs
+++ b/src/SharpGLTF.Core/Schema2/gltf.BufferView.cs
@@ -322,7 +322,7 @@ namespace SharpGLTF.Schema2
 
             var content = new BYTES(buffer.Content, byteOffset, byteLength.AsValue(buffer.Content.Length - byteOffset) );
 
-            if(searchForExisting)
+            if (searchForExisting)
             {
                 foreach (var bv in this.LogicalBufferViews)
                 {

--- a/src/SharpGLTF.Core/Schema2/gltf.BufferView.cs
+++ b/src/SharpGLTF.Core/Schema2/gltf.BufferView.cs
@@ -301,7 +301,7 @@ namespace SharpGLTF.Schema2
         public BufferView UseBufferView(Byte[] buffer, int byteOffset = 0, int? byteLength = null, int byteStride = 0, BufferMode? target = null, bool searchForExisting = true)
         {
             Guard.NotNull(buffer, nameof(buffer));
-            return UseBufferView(UseBuffer(buffer), byteOffset, byteLength, byteStride, target, searchForExisting);
+            return UseBufferView(UseBuffer(buffer, false), byteOffset, byteLength, byteStride, target, searchForExisting);
         }
 
         /// <summary>

--- a/src/SharpGLTF.Core/Schema2/gltf.BufferView.cs
+++ b/src/SharpGLTF.Core/Schema2/gltf.BufferView.cs
@@ -279,11 +279,12 @@ namespace SharpGLTF.Schema2
         /// <param name="data">The array range to wrap.</param>
         /// <param name="byteStride">For strided vertex buffers, it must be a value multiple of 4, 0 otherwise</param>
         /// <param name="target">The type hardware device buffer, or null</param>
+        /// <param name="searchForExisting">Whether the function should search for an already existing buffer with the same content</param>
         /// <returns>A <see cref="BufferView"/> instance.</returns>
-        public BufferView UseBufferView(BYTES data, int byteStride = 0, BufferMode? target = null)
+        public BufferView UseBufferView(BYTES data, int byteStride = 0, BufferMode? target = null, bool searchForExisting = true)
         {
             Guard.NotNull(data.Array, nameof(data));
-            return UseBufferView(data.Array, data.Offset, data.Count, byteStride, target);
+            return UseBufferView(data.Array, data.Offset, data.Count, byteStride, target, searchForExisting);
         }
 
         /// <summary>
@@ -295,11 +296,12 @@ namespace SharpGLTF.Schema2
         /// <param name="byteLength">The number of elements in <paramref name="buffer"/></param>
         /// <param name="byteStride">For strided vertex buffers, it must be a value multiple of 4, 0 otherwise</param>
         /// <param name="target">The type hardware device buffer, or null</param>
+        /// <param name="searchForExisting">Whether the function should search for an already existing buffer with the same content</param>
         /// <returns>A <see cref="BufferView"/> instance.</returns>
-        public BufferView UseBufferView(Byte[] buffer, int byteOffset = 0, int? byteLength = null, int byteStride = 0, BufferMode? target = null)
+        public BufferView UseBufferView(Byte[] buffer, int byteOffset = 0, int? byteLength = null, int byteStride = 0, BufferMode? target = null, bool searchForExisting = true)
         {
             Guard.NotNull(buffer, nameof(buffer));
-            return UseBufferView(UseBuffer(buffer), byteOffset, byteLength, byteStride, target);
+            return UseBufferView(UseBuffer(buffer), byteOffset, byteLength, byteStride, target, searchForExisting);
         }
 
         /// <summary>
@@ -311,17 +313,21 @@ namespace SharpGLTF.Schema2
         /// <param name="byteLength">The number of elements in <paramref name="buffer"/></param>
         /// <param name="byteStride">For strided vertex buffers, it must be a value multiple of 4, 0 otherwise</param>
         /// <param name="target">The type hardware device buffer, or null</param>
+        /// <param name="searchForExisting">Whether the function should search for an already existing buffer with the same content</param>
         /// <returns>A <see cref="BufferView"/> instance.</returns>
-        public BufferView UseBufferView(Buffer buffer, int byteOffset = 0, int? byteLength = null, int byteStride = 0, BufferMode? target = null)
+        public BufferView UseBufferView(Buffer buffer, int byteOffset = 0, int? byteLength = null, int byteStride = 0, BufferMode? target = null, bool searchForExisting = true)
         {
             Guard.NotNull(buffer, nameof(buffer));
             Guard.MustShareLogicalParent(this, "this", buffer, nameof(buffer));
 
             var content = new BYTES(buffer.Content, byteOffset, byteLength.AsValue(buffer.Content.Length - byteOffset) );
 
-            foreach (var bv in this.LogicalBufferViews)
+            if(searchForExisting)
             {
-                if (BufferView.AreEqual(bv, content, byteStride, target)) return bv;
+                foreach (var bv in this.LogicalBufferViews)
+                {
+                    if (BufferView.AreEqual(bv, content, byteStride, target)) return bv;
+                }
             }
 
             var newbv = new BufferView(buffer, byteOffset, byteLength, byteStride, target);


### PR DESCRIPTION
This PR is an attempt at fixing #71.

## Changes:
* Added `searchForExisting` parameter to `UseBufferView` which dictates whether the function should search for an already existing buffer with the same content
* * This is especially useful in the context of animations, where there is rarely the same data
* `CreateInputAccessor` and `CreateOutputAccessor` now accepts an `IEnumerable` instead of an `IReadOnlyList`.
* * Related to change in the `Split` function which now no longer copies data to new arrays but rather returns references to the inner sorted dictionary Keys and Values

## Result
I was able to achieve around a 50% increase in performance while creating animation channels.
The time it takes to do this same exact task with the test files provided in the issue in the current version of `SharpGLTF` takes around 3.5 minutes on my machine. This PR reduces that time to 2 minutes.
![devenv_sRhY7p46Qm](https://user-images.githubusercontent.com/18646077/91992455-72e64f80-ed34-11ea-9e99-2aa229f0dcbc.png)

Generated file:
[GeneratedFile.zip](https://github.com/vpenades/SharpGLTF/files/5162699/GeneratedFile.zip)
