### PR TITLE
Allow client code to supply its own extensions

### DIFF
--- a/src/SharpGLTF.Core/Schema2/gltf.ExtensionsFactory.cs
+++ b/src/SharpGLTF.Core/Schema2/gltf.ExtensionsFactory.cs
@@ -7,7 +7,7 @@ using SharpGLTF.IO;
 
 namespace SharpGLTF.Schema2
 {
-    static class ExtensionsFactory
+    public static class ExtensionsFactory
     {
         // extensions design inconsistencies:
         // https://github.com/KhronosGroup/glTF/issues/1491
@@ -71,7 +71,7 @@ namespace SharpGLTF.Schema2
             var instance = Activator.CreateInstance
                 (
                 extType,
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
                 null,
                 new Object[] { parent },
                 null


### PR DESCRIPTION
I'm not sure if you want this change or not, but this allows client apps to register and use their own extensions.

Fixes #93.