### PR TITLE
Add arbitrary file extension

### DIFF
--- a/src/SharpGLTF.Core/Schema2/Serialization.WriteSettings.cs
+++ b/src/SharpGLTF.Core/Schema2/Serialization.WriteSettings.cs
@@ -186,7 +186,7 @@ namespace SharpGLTF.Schema2
                 filePath = finfo.Name;
             }
 
-            var name = Path.GetFileNameWithoutExtension(filePath);
+            var name = Path.GetFileName(filePath);
 
             context.WithBinarySettings();
 
@@ -216,7 +216,7 @@ namespace SharpGLTF.Schema2
                 filePath = finfo.Name;
             }
 
-            var name = Path.GetFileNameWithoutExtension(filePath);
+            var name = Path.GetFileName(filePath);
 
             context.WithTextSettings();
             


### PR DESCRIPTION
Allows the user to choose a main file extension for the methods SaveGLB, SaveGLTF instead of always forcing the default ones.

This could be useful in many cases and doesn't change any logic.
The associated resources will use the base name followed by their extensions anyway.