### PR TITLE
add 3d tiles metadata noData and default support

### DIFF
--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.Features.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.Features.cs
@@ -336,7 +336,7 @@ namespace SharpGLTF.Schema2
                     {
                         var expectedTexCoordAttribute = $"TEXCOORD_{texture.TextureCoordinate}";
                         var vertex = _meshPrimitive.GetVertexAccessor(expectedTexCoordAttribute);
-                        var distinctFeatureIds = vertex.AsVector2Array().Count();
+                        var distinctFeatureIds = vertex.AsVector2Array().Count;
 
                         Guard.IsTrue(featureId.FeatureCount == distinctFeatureIds, $"Mismatch between FeatureCount ({featureId.FeatureCount}) and Feature Texture ({distinctFeatureIds})");
 

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -233,7 +233,6 @@ namespace SharpGLTF.Schema2
                     var regex = "^[a-zA-Z_][a-zA-Z0-9_]*$";
                     Guard.IsTrue(System.Text.RegularExpressions.Regex.IsMatch(Schema.Id, regex), nameof(Schema.Id));
 
-
                     foreach (var _class in Schema.Classes)
                     {
                         Guard.IsTrue(System.Text.RegularExpressions.Regex.IsMatch(_class.Key, regex), nameof(_class.Key));
@@ -243,6 +242,17 @@ namespace SharpGLTF.Schema2
                             if (property.Value.Count.HasValue)
                             {
                                 Guard.MustBeGreaterThanOrEqualTo(property.Value.Count.Value, 2, nameof(property.Value.Count));
+                            }
+
+                            if (property.Value.Required)
+                            {
+                                Guard.IsTrue(property.Value.NoData == null, nameof(property.Value.NoData), $"The property '{property.Key}' defines a 'noData' value, but is 'required'");
+                            }
+
+                            if(property.Value.Type == ELEMENTTYPE.SCALAR)
+                            {
+                                // check The 'componentType' must be defined for a property with type 'SCALAR'
+                                Guard.IsTrue(property.Value.ComponentType.HasValue, nameof(property.Value.ComponentType), $"The 'componentType' must be defined for a property '{property.Key}' with type 'SCALAR'");
                             }
                         }
                     }
@@ -843,13 +853,13 @@ namespace SharpGLTF.Schema2
 
             private void CheckScalarTypes<T>(DATATYPE? componentType)
             {
-                if (componentType == DATATYPE.INT8)
-                {
-                    Guard.IsTrue(typeof(T) == typeof(sbyte), nameof(T), $"Scalar value type of property {LogicalKey} must be sbyte");
-                }
-                else if (componentType == DATATYPE.UINT8)
+                if (componentType == DATATYPE.UINT8)
                 {
                     Guard.IsTrue(typeof(T) == typeof(byte), nameof(T), $"Scalar value type of property {LogicalKey} must be byte");
+                }
+                else if (componentType == DATATYPE.INT8)
+                {
+                    Guard.IsTrue(typeof(T) == typeof(sbyte), nameof(T), $"Scalar value type of property {LogicalKey} must be sbyte");
                 }
                 else if (componentType == DATATYPE.INT16)
                 {
@@ -1227,6 +1237,7 @@ namespace SharpGLTF.Schema2
             #endregion
 
             #region properties
+
             public string Name
             {
                 get => _name;
@@ -1261,6 +1272,11 @@ namespace SharpGLTF.Schema2
             {
                 get => _required ?? _requiredDefault;
                 set => _required = value.AsNullable(_requiredDefault);
+            }
+
+            public JsonNode NoData
+            {
+                get => _noData;
             }
 
             public bool Normalized
@@ -1325,9 +1341,10 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithStringType()
+            public StructuralMetadataClassProperty WithStringType(string noData = null)
             {
                 Type = ElementType.STRING;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
@@ -1337,73 +1354,83 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt8Type()
+            public StructuralMetadataClassProperty WithUInt8Type(byte? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT8;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt8Type()
+            public StructuralMetadataClassProperty WithInt8Type(sbyte? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT8;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt16Type()
+            public StructuralMetadataClassProperty WithUInt16Type(ushort? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT16;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt16Type()
+            public StructuralMetadataClassProperty WithInt16Type(short? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT16;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt32Type()
+            public StructuralMetadataClassProperty WithUInt32Type(uint? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT32;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt32Type()
+            public StructuralMetadataClassProperty WithInt32Type(int? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT32;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt64Type()
+            public StructuralMetadataClassProperty WithUInt64Type(ulong? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT64;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt64Type()
+            public StructuralMetadataClassProperty WithInt64Type(long? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT64;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithFloat32Type()
+            public StructuralMetadataClassProperty WithFloat32Type(float? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.FLOAT32;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithFloat64Type()
+            public StructuralMetadataClassProperty WithFloat64Type(double? noData = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.FLOAT64;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
@@ -1429,16 +1456,95 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
+            public StructuralMetadataClassProperty WithBooleanArrayType(int? count = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.BOOLEAN, null, count);
+                return property;
+            }
 
-            //public StructuralMetadataClassProperty WithValueType(ELEMENTTYPE etype, DATATYPE? ctype = null)
-            //{
-            //    Type = etype;
-            //    ComponentType = ctype;
-            //    Array = false;
-            //    return this;
-            //}
+            public StructuralMetadataClassProperty WithUInt8ArrayType(int? count = null, byte? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.UINT8, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
 
-            public StructuralMetadataClassProperty WithArrayType(ELEMENTTYPE etype, DATATYPE? ctype = null, int? count = null)
+            public StructuralMetadataClassProperty WithInt8ArrayType(int? count = null, sbyte? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.INT8, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+
+            public StructuralMetadataClassProperty WithInt16ArrayType(int? count = null, short? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.INT16, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+
+            public StructuralMetadataClassProperty WithUInt16ArrayType(int? count = null, ushort? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.UINT16, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+            public StructuralMetadataClassProperty WithInt32ArrayType(int? count = null, int? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.INT32, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+            public StructuralMetadataClassProperty WithUInt32ArrayType(int? count = null, uint? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.UINT32, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+            public StructuralMetadataClassProperty WithInt64ArrayType(int? count = null, long? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.INT64, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+            public StructuralMetadataClassProperty WithUInt64ArrayType(int? count = null, ulong? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.UINT64, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+            public StructuralMetadataClassProperty WithFloat32ArrayType(int? count = null, float? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.FLOAT32, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+            public StructuralMetadataClassProperty WithFloat64ArrayType(int? count = null, double? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.SCALAR, DATATYPE.FLOAT64, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+
+            public StructuralMetadataClassProperty WithVector3ArrayType(int? count = null, Vector3? noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.VEC3, DATATYPE.FLOAT32, count);
+                // todo: how to set noData for vector3?
+                return property;
+            }
+            public StructuralMetadataClassProperty WithMatrix4x4ArrayType(int? count = null)
+            {
+                return WithArrayType(ELEMENTTYPE.MAT4, DATATYPE.FLOAT32, count);
+            }
+
+            public StructuralMetadataClassProperty WithStringArrayType(int? count = null, string noData = null)
+            {
+                var property = WithArrayType(ELEMENTTYPE.STRING, null, count);
+                if (noData != null) property._noData = noData;
+                return property;
+            }
+
+            private StructuralMetadataClassProperty WithArrayType(ELEMENTTYPE etype, DATATYPE? ctype = null, int? count = null)
             {
                 Type = etype;
                 ComponentType = ctype;
@@ -1447,19 +1553,21 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithEnumArrayType(StructuralMetadataEnum enumeration, int? count = null)
+            public StructuralMetadataClassProperty WithEnumArrayType(StructuralMetadataEnum enumeration, int? count = null, string noData = null)
             {
                 Type = ELEMENTTYPE.ENUM;
                 _enumType = enumeration.LogicalKey;
                 Array = true;
                 Count = count;
+                if (noData != null) _noData = noData;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithEnumeration(StructuralMetadataEnum enumeration)
+            public StructuralMetadataClassProperty WithEnumeration(StructuralMetadataEnum enumeration, string noData = null)
             {
                 Type = ELEMENTTYPE.ENUM;
                 _enumType = enumeration.LogicalKey;
+                if (noData != null) _noData = noData;
                 return this;
             }
 

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -14,6 +14,7 @@ namespace SharpGLTF.Schema2
     using Tiles3D;
     using System.Numerics;
     using System.Text.Json.Nodes;
+    using System.ComponentModel;
 
     partial class Tiles3DExtensions
     {
@@ -1341,10 +1342,11 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithStringType(string noData = null)
+            public StructuralMetadataClassProperty WithStringType(string noData = null, string defaultValue = null)
             {
                 Type = ElementType.STRING;
                 if (noData != null) _noData = noData;
+                if(defaultValue != null) _default = defaultValue;
                 return this;
             }
 
@@ -1354,88 +1356,98 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt8Type(byte? noData = null)
+            public StructuralMetadataClassProperty WithUInt8Type(byte? noData = null, byte? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT8;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt8Type(sbyte? noData = null)
+            public StructuralMetadataClassProperty WithInt8Type(sbyte? noData = null, sbyte? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT8;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt16Type(ushort? noData = null)
+            public StructuralMetadataClassProperty WithUInt16Type(ushort? noData = null, ushort? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT16;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt16Type(short? noData = null)
+            public StructuralMetadataClassProperty WithInt16Type(short? noData = null, short? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT16;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt32Type(uint? noData = null)
+            public StructuralMetadataClassProperty WithUInt32Type(uint? noData = null, uint? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT32;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt32Type(int? noData = null)
+            public StructuralMetadataClassProperty WithInt32Type(int? noData = null, int? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT32;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithUInt64Type(ulong? noData = null)
+            public StructuralMetadataClassProperty WithUInt64Type(ulong? noData = null, ulong? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.UINT64;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithInt64Type(long? noData = null)
+            public StructuralMetadataClassProperty WithInt64Type(long? noData = null, long? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.INT64;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithFloat32Type(float? noData = null)
+            public StructuralMetadataClassProperty WithFloat32Type(float? noData = null, float? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.FLOAT32;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithFloat64Type(double? noData = null)
+            public StructuralMetadataClassProperty WithFloat64Type(double? noData = null, double? defaultValue = null)
             {
                 Type = ELEMENTTYPE.SCALAR;
                 ComponentType = DATATYPE.FLOAT64;
                 if (noData != null) _noData = noData;
+                if (defaultValue != null) _default = defaultValue;
                 return this;
             }
 
 
-            public StructuralMetadataClassProperty WithVector3Type(Vector3? noData = null)
+            public StructuralMetadataClassProperty WithVector3Type(Vector3? noData = null, Vector3? defaultValue = null)
             {
                 Type = ElementType.VEC3;
                 ComponentType = DataType.FLOAT32;
@@ -1444,10 +1456,15 @@ namespace SharpGLTF.Schema2
                 {
                     _noData = new JsonArray(noData.Value.X, noData.Value.Y, noData.Value.Z);
                 }
+                if (defaultValue != null)
+                {
+                    _default = new JsonArray(defaultValue.Value.X, defaultValue.Value.Y, defaultValue.Value.Z);
+                }
+
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithMatrix4x4Type(Matrix4x4? noData = null)
+            public StructuralMetadataClassProperty WithMatrix4x4Type(Matrix4x4? noData = null, Matrix4x4? defaultValue = null)
             {
                 Type = ElementType.MAT4;
                 ComponentType = DataType.FLOAT32;
@@ -1456,6 +1473,16 @@ namespace SharpGLTF.Schema2
                 {
                     var m4 = noData.Value;
                     _noData = new JsonArray(
+                        m4.M11, m4.M12, m4.M13, m4.M14,
+                        m4.M21, m4.M22, m4.M23, m4.M24,
+                        m4.M31, m4.M32, m4.M33, m4.M34,
+                        m4.M41, m4.M42, m4.M43, m4.M44);
+                }
+
+                if (defaultValue != null)
+                {
+                    var m4 = defaultValue.Value;
+                    _default = new JsonArray(
                         m4.M11, m4.M12, m4.M13, m4.M14,
                         m4.M21, m4.M22, m4.M23, m4.M24,
                         m4.M31, m4.M32, m4.M33, m4.M34,
@@ -1598,37 +1625,6 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-            /**
-            private static JsonArray ToJsonArray(Vector3 vector3)
-            {
-                var floats = new float[] { vector3.X, vector3.Y, vector3.Z };
-                var  jsonNode = ToJsonArray(floats);
-                return jsonNode;
-            }
-
-            private static JsonArray ToJsonArray(Matrix4x4 matrix4x4)
-            {
-                var floats = new float[] {
-                    matrix4x4.M11, matrix4x4.M12, matrix4x4.M13, matrix4x4.M14,
-                    matrix4x4.M21, matrix4x4.M22, matrix4x4.M23, matrix4x4.M24,
-                    matrix4x4.M31, matrix4x4.M32, matrix4x4.M33, matrix4x4.M34,
-                    matrix4x4.M41, matrix4x4.M42, matrix4x4.M43, matrix4x4.M44
-                };
-
-                var jsonNode = ToJsonArray(floats);
-                return jsonNode;
-            }
-
-            private static JsonArray ToJsonArray(float[] floats)
-            {
-                var jsonNode = new JsonArray();
-                foreach (var f in floats)
-                {
-                    jsonNode.Add(f);
-                }
-
-                return jsonNode;
-            }*/
 
             #endregion
         }

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -1442,9 +1442,7 @@ namespace SharpGLTF.Schema2
 
                 if (noData != null)
                 {
-                    var jsonNode = ToJsonArray(noData.Value);
-                    _noData = jsonNode;
-
+                    _noData = new JsonArray(noData.Value.X, noData.Value.Y, noData.Value.Z);
                 }
                 return this;
             }
@@ -1456,8 +1454,12 @@ namespace SharpGLTF.Schema2
 
                 if (noData != null)
                 {
-                    var jsonNode = ToJsonArray(noData.Value);
-                    _noData = jsonNode;
+                    var m4 = noData.Value;
+                    _noData = new JsonArray(
+                        m4.M11, m4.M12, m4.M13, m4.M14,
+                        m4.M21, m4.M22, m4.M23, m4.M24,
+                        m4.M31, m4.M32, m4.M33, m4.M34,
+                        m4.M41, m4.M42, m4.M43, m4.M44);
                 }
 
                 return this;
@@ -1596,7 +1598,7 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-
+            /**
             private static JsonArray ToJsonArray(Vector3 vector3)
             {
                 var floats = new float[] { vector3.X, vector3.Y, vector3.Z };
@@ -1626,7 +1628,7 @@ namespace SharpGLTF.Schema2
                 }
 
                 return jsonNode;
-            }
+            }*/
 
             #endregion
         }

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -1579,10 +1579,25 @@ namespace SharpGLTF.Schema2
                 return WithArrayType(ELEMENTTYPE.MAT4, DATATYPE.FLOAT32, count);
             }
 
-            public StructuralMetadataClassProperty WithStringArrayType(int? count = null, string noData = null)
+            public StructuralMetadataClassProperty WithStringArrayType(int? count = null, List<string> noData = null, List<string> defaultValue = null)
             {
                 var property = WithArrayType(ELEMENTTYPE.STRING, null, count);
-                if (noData != null) property._noData = noData;
+                if (noData != null)
+                {
+                    var arr = noData.ToArray();
+                    var jsonNodes = new List<JsonNode>();
+                    foreach(var item in arr)
+                    {
+                        jsonNodes.Add(item);
+                    }
+                    var jsonArray = new JsonArray(jsonNodes.ToArray());
+
+                    property._noData = jsonArray;
+                }
+                if (noData != null)
+                {
+                    property._default = new JsonArray(defaultValue[0]);
+                }
                 return property;
             }
 

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -1254,7 +1254,7 @@ namespace SharpGLTF.Schema2
             internal ELEMENTTYPE Type
             {
                 get => _type;
-                set => _type = value;
+                // set => _type = value;
             }
 
             public string EnumType
@@ -1266,7 +1266,7 @@ namespace SharpGLTF.Schema2
             public DATATYPE? ComponentType
             {
                 get => _componentType;
-                set => _componentType = value;
+                // set => _componentType = value;
             }
 
             public bool Required
@@ -1344,7 +1344,7 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithStringType(string noData = null, string defaultValue = null)
             {
-                Type = ElementType.STRING;
+                _type = ElementType.STRING;
                 if (noData != null) _noData = noData;
                 if(defaultValue != null) _default = defaultValue;
                 return this;
@@ -1352,14 +1352,14 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithBooleanType()
             {
-                Type = ElementType.BOOLEAN;
+                _type = ElementType.BOOLEAN;
                 return this;
             }
 
             public StructuralMetadataClassProperty WithUInt8Type(byte? noData = null, byte? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.UINT8;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.UINT8;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1367,8 +1367,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithInt8Type(sbyte? noData = null, sbyte? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.INT8;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.INT8;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1376,8 +1376,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithUInt16Type(ushort? noData = null, ushort? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.UINT16;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.UINT16;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1385,8 +1385,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithInt16Type(short? noData = null, short? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.INT16;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.INT16;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1394,8 +1394,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithUInt32Type(uint? noData = null, uint? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.UINT32;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.UINT32;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1403,8 +1403,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithInt32Type(int? noData = null, int? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.INT32;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.INT32;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1412,8 +1412,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithUInt64Type(ulong? noData = null, ulong? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.UINT64;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.UINT64;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1421,8 +1421,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithInt64Type(long? noData = null, long? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.INT64;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.INT64;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1430,8 +1430,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithFloat32Type(float? noData = null, float? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.FLOAT32;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.FLOAT32;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1439,8 +1439,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithFloat64Type(double? noData = null, double? defaultValue = null)
             {
-                Type = ELEMENTTYPE.SCALAR;
-                ComponentType = DATATYPE.FLOAT64;
+                _type = ELEMENTTYPE.SCALAR;
+                _componentType = DATATYPE.FLOAT64;
                 if (noData != null) _noData = noData;
                 if (defaultValue != null) _default = defaultValue;
                 return this;
@@ -1449,8 +1449,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithVector3Type(Vector3? noData = null, Vector3? defaultValue = null)
             {
-                Type = ElementType.VEC3;
-                ComponentType = DataType.FLOAT32;
+                _type = ElementType.VEC3;
+                _componentType = DataType.FLOAT32;
 
                 if (noData != null)
                 {
@@ -1466,8 +1466,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithMatrix4x4Type(Matrix4x4? noData = null, Matrix4x4? defaultValue = null)
             {
-                Type = ElementType.MAT4;
-                ComponentType = DataType.FLOAT32;
+                _type = ElementType.MAT4;
+                _componentType = DataType.FLOAT32;
 
                 if (noData != null)
                 {
@@ -1494,8 +1494,8 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithCount()
             {
-                Type = ElementType.MAT4;
-                ComponentType = DataType.FLOAT32;
+                _type = ElementType.MAT4;
+                _componentType = DataType.FLOAT32;
                 return this;
             }
 
@@ -1586,8 +1586,8 @@ namespace SharpGLTF.Schema2
 
             private StructuralMetadataClassProperty WithArrayType(ELEMENTTYPE etype, DATATYPE? ctype = null, int? count = null)
             {
-                Type = etype;
-                ComponentType = ctype;
+                _type = etype;
+                _componentType = ctype;
                 Array = true;
                 Count = count;
                 return this;
@@ -1595,7 +1595,7 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithEnumArrayType(StructuralMetadataEnum enumeration, int? count = null, string noData = null)
             {
-                Type = ELEMENTTYPE.ENUM;
+                _type = ELEMENTTYPE.ENUM;
                 _enumType = enumeration.LogicalKey;
                 Array = true;
                 Count = count;
@@ -1605,7 +1605,7 @@ namespace SharpGLTF.Schema2
 
             public StructuralMetadataClassProperty WithEnumeration(StructuralMetadataEnum enumeration, string noData = null)
             {
-                Type = ELEMENTTYPE.ENUM;
+                _type = ELEMENTTYPE.ENUM;
                 _enumType = enumeration.LogicalKey;
                 if (noData != null) _noData = noData;
                 return this;

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -1435,17 +1435,31 @@ namespace SharpGLTF.Schema2
             }
 
 
-            public StructuralMetadataClassProperty WithVector3Type()
+            public StructuralMetadataClassProperty WithVector3Type(Vector3? noData = null)
             {
                 Type = ElementType.VEC3;
                 ComponentType = DataType.FLOAT32;
+
+                if (noData != null)
+                {
+                    var jsonNode = ToJsonArray(noData.Value);
+                    _noData = jsonNode;
+
+                }
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithMatrix4x4Type()
+            public StructuralMetadataClassProperty WithMatrix4x4Type(Matrix4x4? noData = null)
             {
                 Type = ElementType.MAT4;
                 ComponentType = DataType.FLOAT32;
+
+                if (noData != null)
+                {
+                    var jsonNode = ToJsonArray(noData.Value);
+                    _noData = jsonNode;
+                }
+
                 return this;
             }
 
@@ -1529,7 +1543,6 @@ namespace SharpGLTF.Schema2
             public StructuralMetadataClassProperty WithVector3ArrayType(int? count = null, Vector3? noData = null)
             {
                 var property = WithArrayType(ELEMENTTYPE.VEC3, DATATYPE.FLOAT32, count);
-                // todo: how to set noData for vector3?
                 return property;
             }
             public StructuralMetadataClassProperty WithMatrix4x4ArrayType(int? count = null)
@@ -1583,6 +1596,37 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
+
+            private static JsonArray ToJsonArray(Vector3 vector3)
+            {
+                var floats = new float[] { vector3.X, vector3.Y, vector3.Z };
+                var  jsonNode = ToJsonArray(floats);
+                return jsonNode;
+            }
+
+            private static JsonArray ToJsonArray(Matrix4x4 matrix4x4)
+            {
+                var floats = new float[] {
+                    matrix4x4.M11, matrix4x4.M12, matrix4x4.M13, matrix4x4.M14,
+                    matrix4x4.M21, matrix4x4.M22, matrix4x4.M23, matrix4x4.M24,
+                    matrix4x4.M31, matrix4x4.M32, matrix4x4.M33, matrix4x4.M34,
+                    matrix4x4.M41, matrix4x4.M42, matrix4x4.M43, matrix4x4.M44
+                };
+
+                var jsonNode = ToJsonArray(floats);
+                return jsonNode;
+            }
+
+            private static JsonArray ToJsonArray(float[] floats)
+            {
+                var jsonNode = new JsonArray();
+                foreach (var f in floats)
+                {
+                    jsonNode.Add(f);
+                }
+
+                return jsonNode;
+            }
 
             #endregion
         }

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -1579,26 +1579,9 @@ namespace SharpGLTF.Schema2
                 return WithArrayType(ELEMENTTYPE.MAT4, DATATYPE.FLOAT32, count);
             }
 
-            public StructuralMetadataClassProperty WithStringArrayType(int? count = null, List<string> noData = null, List<string> defaultValue = null)
+            public StructuralMetadataClassProperty WithStringArrayType(int? count = null)
             {
-                var property = WithArrayType(ELEMENTTYPE.STRING, null, count);
-                if (noData != null)
-                {
-                    var arr = noData.ToArray();
-                    var jsonNodes = new List<JsonNode>();
-                    foreach(var item in arr)
-                    {
-                        jsonNodes.Add(item);
-                    }
-                    var jsonArray = new JsonArray(jsonNodes.ToArray());
-
-                    property._noData = jsonArray;
-                }
-                if (noData != null)
-                {
-                    property._default = new JsonArray(defaultValue[0]);
-                }
-                return property;
+                return WithArrayType(ELEMENTTYPE.STRING, null, count);
             }
 
             private StructuralMetadataClassProperty WithArrayType(ELEMENTTYPE etype, DATATYPE? ctype = null, int? count = null)

--- a/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
+++ b/src/SharpGLTF.Ext.3DTiles/Schema2/Ext.StructuralMetadataRoot.cs
@@ -1469,13 +1469,6 @@ namespace SharpGLTF.Schema2
                 return this;
             }
 
-            public StructuralMetadataClassProperty WithCount()
-            {
-                _type = ElementType.MAT4;
-                _componentType = DataType.FLOAT32;
-                return this;
-            }
-
             public StructuralMetadataClassProperty WithBooleanArrayType(int? count = null)
             {
                 var property = WithArrayType(ELEMENTTYPE.BOOLEAN, null, count);

--- a/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
+++ b/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
@@ -182,12 +182,6 @@ namespace SharpGLTF.Schema2.Tiles3D
                 .UseProperty("matrix4x4")
                 .WithMatrix4x4Type(Matrix4x4.Identity * -10);
 
-            var stringArrayProperty = schemaClass
-                .UseProperty("stringArray")
-                .WithStringArrayType(noData: ["test0", "test1"], defaultValue: ["nothing"]);
-
-            // todo add array types
-
             var propertyTable = schemaClass.AddPropertyTable(1);
 
             propertyTable
@@ -250,13 +244,6 @@ namespace SharpGLTF.Schema2.Tiles3D
             propertyTable
                 .UseProperty(matrix4x4Property)
                 .SetValues(m4);
-
-            var strings = new List<List<string>>();
-            strings.Add(["test0", "test1"]);
-
-            propertyTable
-                .UseProperty(stringArrayProperty)
-                .SetArrayValues(strings);
 
             foreach (var primitive in model.LogicalMeshes[0].Primitives)
             {

--- a/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
+++ b/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
@@ -253,7 +253,6 @@ namespace SharpGLTF.Schema2.Tiles3D
                 primitive.AddMeshFeatureIds(featureIdAttribute);
             }
 
-            model.SaveGLTF(@"D:\dev\github.com\bertt\cesium_issues\vector3_float32_nodata\vector3_float32_nodata.gltf");
             // create files
             var ctx = new ValidationResult(model, ValidationMode.Strict, true);
             model.AttachToCurrentTest("cesium_ext_structural_minimal_metadata_sample.glb");

--- a/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
+++ b/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
@@ -182,6 +182,10 @@ namespace SharpGLTF.Schema2.Tiles3D
                 .UseProperty("matrix4x4")
                 .WithMatrix4x4Type(Matrix4x4.Identity * -10);
 
+            var stringArrayProperty = schemaClass
+                .UseProperty("stringArray")
+                .WithStringArrayType(noData: ["test0", "test1"], defaultValue: ["nothing"]);
+
             // todo add array types
 
             var propertyTable = schemaClass.AddPropertyTable(1);
@@ -246,6 +250,13 @@ namespace SharpGLTF.Schema2.Tiles3D
             propertyTable
                 .UseProperty(matrix4x4Property)
                 .SetValues(m4);
+
+            var strings = new List<List<string>>();
+            strings.Add(["test0", "test1"]);
+
+            propertyTable
+                .UseProperty(stringArrayProperty)
+                .SetArrayValues(strings);
 
             foreach (var primitive in model.LogicalMeshes[0].Primitives)
             {

--- a/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
+++ b/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
@@ -120,9 +120,11 @@ namespace SharpGLTF.Schema2.Tiles3D
                     .UseProperty("description")
                     .WithStringType();
 
+            // for this property, the default value (byte.MaxValue) should be shown in the client when the actual value is 
+            // equal to the noData value (byte.MinValue)
             var uint8Property = schemaClass
                 .UseProperty("uint8")
-                .WithUInt8Type(byte.MinValue);
+                .WithUInt8Type(byte.MinValue, byte.MaxValue);
 
             var int8Property = schemaClass
                 .UseProperty("int8")
@@ -164,7 +166,7 @@ namespace SharpGLTF.Schema2.Tiles3D
 
             var stringProperty = schemaClass
                 .UseProperty("string")
-                .WithStringType("noData");
+                .WithStringType("noData", "-");
 
             var speciesProperty = schemaClass
                 .UseProperty("species")
@@ -251,6 +253,7 @@ namespace SharpGLTF.Schema2.Tiles3D
                 primitive.AddMeshFeatureIds(featureIdAttribute);
             }
 
+            model.SaveGLTF(@"D:\dev\github.com\bertt\cesium_issues\vector3_float32_nodata\vector3_float32_nodata.gltf");
             // create files
             var ctx = new ValidationResult(model, ValidationMode.Strict, true);
             model.AttachToCurrentTest("cesium_ext_structural_minimal_metadata_sample.glb");

--- a/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
+++ b/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
@@ -112,7 +112,7 @@ namespace SharpGLTF.Schema2.Tiles3D
 
             var schemaClass = schema.UseClassMetadata("triangles");
 
-            var speciesEnum = schema.UseEnumMetadata("speciesEnum", ("Unspecified", 0), ("Oak", 1), ("Pine", 2), ("Maple",3));
+            var speciesEnum = schema.UseEnumMetadata("speciesEnum", ("Unspecified", 0), ("Oak", 1), ("Pine", 2), ("Maple", 3));
             speciesEnum.Name = "Species";
             speciesEnum.Description = "An example enum for tree species.";
 
@@ -162,10 +162,6 @@ namespace SharpGLTF.Schema2.Tiles3D
                 .UseProperty("float64")
                 .WithFloat64Type(double.MinValue);
 
-            var vector3Property = schemaClass
-                .UseProperty("vector3")
-                .WithVector3Type();
-
             var stringProperty = schemaClass
                 .UseProperty("string")
                 .WithStringType("noData");
@@ -175,6 +171,14 @@ namespace SharpGLTF.Schema2.Tiles3D
                 .WithDescription("Type of tree.")
                 .WithEnumeration(speciesEnum, "Unspecified")
                 .WithRequired(false);
+
+            var vector3Property = schemaClass
+                .UseProperty("vector3")
+                .WithVector3Type(new Vector3(-10.0f, -10.0f, -10.0f));
+
+            var matrix4x4Property = schemaClass
+                .UseProperty("matrix4x4")
+                .WithMatrix4x4Type(Matrix4x4.Identity * -10);
 
             // todo add array types
 
@@ -224,11 +228,6 @@ namespace SharpGLTF.Schema2.Tiles3D
                 .UseProperty(float64Property)
                 .SetValues(double.MinValue);
 
-            // todo: how to set a vector3 to null?
-            propertyTable
-                .UseProperty(vector3Property)
-                .SetValues(new Vector3(0,0,0));
-
             propertyTable
                 .UseProperty(stringProperty)
                 .SetValues("noData");
@@ -236,6 +235,15 @@ namespace SharpGLTF.Schema2.Tiles3D
             propertyTable
                 .UseProperty(speciesProperty)
                 .SetValues((short)0);
+
+            propertyTable
+                .UseProperty(vector3Property)
+                .SetValues(new Vector3(10.0f,10.0f,10.0f));
+
+            var m4 = Matrix4x4.Identity;
+            propertyTable
+                .UseProperty(matrix4x4Property)
+                .SetValues(m4);
 
             foreach (var primitive in model.LogicalMeshes[0].Primitives)
             {
@@ -249,9 +257,6 @@ namespace SharpGLTF.Schema2.Tiles3D
             model.AttachToCurrentTest("cesium_ext_structural_minimal_metadata_sample.gltf");
             model.AttachToCurrentTest("cesium_ext_structural_minimal_metadata_sample.plotly");
         }
-
-
-
 
         [Test(Description = "MinimalMetadataAttributeSample")]
         public void MinimalMetadataAttributeSample()

--- a/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
+++ b/tests/SharpGLTF.Ext.3DTiles.Tests/ExtStructuralMetadataTests.cs
@@ -82,6 +82,176 @@ namespace SharpGLTF.Schema2.Tiles3D
             }
         }
 
+        /// <summary>
+        /// In this test a single triangle is defined, it has attributes defined for all types with a noData value, 
+        /// but the values are set to the noData value. In CesiumJS the triangle is rendered but the 
+        /// attritutes are not shown (because noData).
+        /// </summary>
+        [Test(Description = "MetadataAndNullValuesAttributeSample")]
+        public void MetadataNullValuesAttributeSample()
+        {
+            TestContext.CurrentContext.AttachGltfValidatorLinks();
+
+            int featureId = 0;
+            var material = MaterialBuilder.CreateDefault().WithDoubleSide(true);
+
+            var mesh = new MeshBuilder<VertexPositionNormal, VertexWithFeatureId, VertexEmpty>("mesh");
+            var prim = mesh.UsePrimitive(material);
+
+            var vt0 = VertexBuilder.GetVertexWithFeatureId(new Vector3(0, 0, 0), new Vector3(0, 0, 1), featureId);
+            var vt1 = VertexBuilder.GetVertexWithFeatureId(new Vector3(1, 0, 0), new Vector3(0, 0, 1), featureId);
+            var vt2 = VertexBuilder.GetVertexWithFeatureId(new Vector3(0, 1, 0), new Vector3(0, 0, 1), featureId);
+
+            prim.AddTriangle(vt0, vt1, vt2);
+            var scene = new SceneBuilder();
+            scene.AddRigidMesh(mesh, Matrix4x4.Identity);
+            var model = scene.ToGltf2();
+
+            var rootMetadata = model.UseStructuralMetadata();
+            var schema = rootMetadata.UseEmbeddedSchema("schema_001");
+
+            var schemaClass = schema.UseClassMetadata("triangles");
+
+            var speciesEnum = schema.UseEnumMetadata("speciesEnum", ("Unspecified", 0), ("Oak", 1), ("Pine", 2), ("Maple",3));
+            speciesEnum.Name = "Species";
+            speciesEnum.Description = "An example enum for tree species.";
+
+            var descriptionProperty = schemaClass
+                    .UseProperty("description")
+                    .WithStringType();
+
+            var uint8Property = schemaClass
+                .UseProperty("uint8")
+                .WithUInt8Type(byte.MinValue);
+
+            var int8Property = schemaClass
+                .UseProperty("int8")
+                .WithInt8Type(sbyte.MinValue);
+
+            var int16Property = schemaClass
+                .UseProperty("int16")
+                .WithInt16Type(short.MinValue);
+
+            var uint16Property = schemaClass
+                .UseProperty("uint16")
+                .WithUInt16Type(ushort.MinValue);
+
+            var int32Property = schemaClass
+                .UseProperty("int32")
+                .WithInt32Type(int.MinValue);
+
+            var uint32Property = schemaClass
+                .UseProperty("uint32")
+                .WithUInt32Type(uint.MinValue);
+
+            var int64Property = schemaClass
+                .UseProperty("int64")
+                .WithInt64Type(long.MinValue);
+
+            var uint64Property = schemaClass
+                .UseProperty("uint64")
+                .WithUInt64Type(ulong.MinValue);
+
+            // when using float.MinValue there is an error in the validator: ""The value has type FLOAT32 and must be in [-3.4028234663852886e+38,3.4028234663852886e+38], but is -3.4028235e+38"
+            // And the noData value is shown in CesiumJS. Therefore we use -10.0f here.
+            var float32Property = schemaClass
+                .UseProperty("float32")
+                .WithFloat32Type(-10.0f);
+
+            var float64Property = schemaClass
+                .UseProperty("float64")
+                .WithFloat64Type(double.MinValue);
+
+            var vector3Property = schemaClass
+                .UseProperty("vector3")
+                .WithVector3Type();
+
+            var stringProperty = schemaClass
+                .UseProperty("string")
+                .WithStringType("noData");
+
+            var speciesProperty = schemaClass
+                .UseProperty("species")
+                .WithDescription("Type of tree.")
+                .WithEnumeration(speciesEnum, "Unspecified")
+                .WithRequired(false);
+
+            // todo add array types
+
+            var propertyTable = schemaClass.AddPropertyTable(1);
+
+            propertyTable
+                .UseProperty(descriptionProperty)
+                .SetValues("Description of the triangle");
+
+            propertyTable
+                .UseProperty(uint8Property)
+                .SetValues(byte.MinValue);
+
+            propertyTable
+                .UseProperty(int8Property)
+                .SetValues(sbyte.MinValue);
+
+            propertyTable
+                .UseProperty(int16Property)
+                .SetValues(short.MinValue);
+
+            propertyTable
+                .UseProperty(uint16Property)
+                .SetValues(ushort.MinValue);
+
+            propertyTable
+                .UseProperty(int32Property)
+                .SetValues(int.MinValue);
+
+            propertyTable
+                .UseProperty(uint32Property)
+                .SetValues(uint.MinValue);
+
+            propertyTable
+                .UseProperty(int64Property)
+                .SetValues(long.MinValue);
+
+            propertyTable
+                .UseProperty(uint64Property)
+                .SetValues(ulong.MinValue);
+
+            propertyTable
+                .UseProperty(float32Property)
+                .SetValues(-10f);
+
+            propertyTable
+                .UseProperty(float64Property)
+                .SetValues(double.MinValue);
+
+            // todo: how to set a vector3 to null?
+            propertyTable
+                .UseProperty(vector3Property)
+                .SetValues(new Vector3(0,0,0));
+
+            propertyTable
+                .UseProperty(stringProperty)
+                .SetValues("noData");
+
+            propertyTable
+                .UseProperty(speciesProperty)
+                .SetValues((short)0);
+
+            foreach (var primitive in model.LogicalMeshes[0].Primitives)
+            {
+                var featureIdAttribute = new FeatureIDBuilder(1, 0, propertyTable);
+                primitive.AddMeshFeatureIds(featureIdAttribute);
+            }
+
+            // create files
+            var ctx = new ValidationResult(model, ValidationMode.Strict, true);
+            model.AttachToCurrentTest("cesium_ext_structural_minimal_metadata_sample.glb");
+            model.AttachToCurrentTest("cesium_ext_structural_minimal_metadata_sample.gltf");
+            model.AttachToCurrentTest("cesium_ext_structural_minimal_metadata_sample.plotly");
+        }
+
+
+
 
         [Test(Description = "MinimalMetadataAttributeSample")]
         public void MinimalMetadataAttributeSample()
@@ -681,21 +851,21 @@ namespace SharpGLTF.Schema2.Tiles3D
                 .UseProperty("example_variable_length_ARRAY_normalized_UINT8")
                 .WithName("Example variable-length ARRAY normalized INT8 property")
                 .WithDescription("An example property, with type ARRAY, with component type UINT8, normalized, and variable length")
-                .WithArrayType(ElementType.SCALAR, DataType.UINT8)
+                .WithUInt8ArrayType()
                 .WithNormalized(false);
 
             var fixedLengthBooleanProperty = exampleMetadataClass
                 .UseProperty("example_fixed_length_ARRAY_BOOLEAN")
                 .WithName("Example fixed-length ARRAY BOOLEAN property")
                 .WithDescription("An example property, with type ARRAY, with component type BOOLEAN, and fixed length ")
-                .WithArrayType(ElementType.BOOLEAN, null, 4)
+                .WithBooleanArrayType(4)
                 .WithNormalized(false);
 
             var variableLengthStringArrayProperty = exampleMetadataClass
                 .UseProperty("example_variable_length_ARRAY_STRING")
                 .WithName("Example variable-length ARRAY STRING property")
                 .WithDescription("An example property, with type ARRAY, with component type STRING, and variable length")
-                .WithArrayType(ElementType.STRING);
+                .WithStringArrayType();
 
             var fixed_length_ARRAY_ENUM = exampleMetadataClass
                 .UseProperty("example_fixed_length_ARRAY_ENUM")


### PR DESCRIPTION
adds support for 3D Tiles - Metadata - noData and default

specs see: https://github.com/CesiumGS/3d-tiles/tree/main/specification/Metadata#required-properties-no-data-values-and-default-values

usecase: when a property value is null, the noData value has to be used. In the client when the property value is equal to the noData value, nothing is shown (or the defaultValue is shown when set).

Limit: noData and defaultValues work for array = false types, not for array= true types

Breaking changes:

- Public set property removed for: Name, Description, Type, EnumType, ComponentType, Required, Normalized, Array, Count

- Public method from public to private: StructuralMetadataClassProperty WithArrayType(ELEMENTTYPE etype, DATATYPE? ctype = null, int? count = null)

- Public Methods added: WithBooleanArrayType, WithUInt8ArrayType,  WithInt8ArrayType, WithInt16ArrayType, WithUInt16ArrayType, WithInt32ArrayType, WithUInt32ArrayType, WithInt64ArrayType, WithUInt64ArrayType, WithFloat32ArrayType, WithFloat64ArrayType, WithVector3ArrayType, WithMatrix4x4ArrayType, WithStringArrayType

Non breaking change:

All property type definition methods now have a nullable noData attribute and nullable defaultValue attribute.
