### PR TITLE
Used SparseWeights8.GetNonZeroWeights() instead of SparseWeights8.GetIndexedWeights() when transforming and generating debugger display.

### DIFF
--- a/src/SharpGLTF.Core/Transforms/MeshTransforms.cs
+++ b/src/SharpGLTF.Core/Transforms/MeshTransforms.cs
@@ -410,7 +410,7 @@ namespace SharpGLTF.Transforms
 
             var wnrm = 1.0f / skinWeights.WeightSum;
 
-            foreach (var (jidx, jweight) in skinWeights.GetIndexedWeights())
+            foreach (var (jidx, jweight) in skinWeights.GetNonZeroWeights())
             {
                 worldPosition += V3.Transform(localPosition, _SkinTransforms[jidx]) * jweight * wnrm;
             }
@@ -424,7 +424,7 @@ namespace SharpGLTF.Transforms
 
             var worldNormal = V3.Zero;
 
-            foreach (var (jidx, jweight) in skinWeights.GetIndexedWeights())
+            foreach (var (jidx, jweight) in skinWeights.GetNonZeroWeights())
             {
                 worldNormal += V3.TransformNormal(localNormal, _SkinTransforms[jidx]) * jweight;
             }
@@ -438,7 +438,7 @@ namespace SharpGLTF.Transforms
 
             var worldTangent = V3.Zero;
 
-            foreach (var (jidx, jweight) in skinWeights.GetIndexedWeights())
+            foreach (var (jidx, jweight) in skinWeights.GetNonZeroWeights())
             {
                 worldTangent += V3.TransformNormal(localTangentV, _SkinTransforms[jidx]) * jweight;
             }

--- a/src/SharpGLTF.Core/Transforms/SparseWeight8.cs
+++ b/src/SharpGLTF.Core/Transforms/SparseWeight8.cs
@@ -33,8 +33,7 @@ namespace SharpGLTF.Transforms
 
         private string _GetDebuggerDisplay()
         {
-            var iw = this.GetIndexedWeights()
-                .Where(item => item.Weight != 0)
+            var iw = this.GetNonZeroWeights()
                 .Select(item => $"[{item.Index}]={item.Weight}");
 
             var txt = string.Join(" ", iw);


### PR DESCRIPTION
This saves some redundant matrix math, optimizing mesh transform calculations.