### PR TITLE
Prevent exceptions when loading files missing texture files

### DIFF
--- a/src/SharpGLTF.Core/Schema2/Serialization.ReadContext.cs
+++ b/src/SharpGLTF.Core/Schema2/Serialization.ReadContext.cs
@@ -48,8 +48,17 @@ namespace SharpGLTF.Schema2
             BYTES _loadFile(string rawUri)
             {
                 var path = _uriSolver(rawUri);
-                var content = File.ReadAllBytes(path);
-                return new BYTES(content);
+
+                try
+                {
+                    var content = File.ReadAllBytes(path);
+
+                    return new BYTES(content);
+                }
+                catch(FileNotFoundException)
+                {
+                    return new BYTES(Array.Empty<byte>());
+                }
             }
 
             return new ReadContext(_loadFile, _uriSolver);

--- a/src/SharpGLTF.Toolkit/Schema2/MaterialExtensions.cs
+++ b/src/SharpGLTF.Toolkit/Schema2/MaterialExtensions.cs
@@ -177,9 +177,16 @@ namespace SharpGLTF.Schema2
         /// <returns>A <see cref="Image"/> instance.</returns>
         public static Image UseImageWithFile(this ModelRoot root, string filePath)
         {
-            var content = System.IO.File.ReadAllBytes(filePath);
+            try
+            {
+                var content = System.IO.File.ReadAllBytes(filePath);
 
-            return root.UseImageWithContent(content);
+                return root.UseImageWithContent(content);
+            }
+            catch(System.IO.FileNotFoundException)
+            {
+                return root.UseImageWithContent(Array.Empty<byte>());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This prevents an exception being thrown when loading a file with missing external texture files.

I'm unsure if this is the best choice for how to do this, but I'm happy to adjust where needed!

The reasoning of this is that it doesn't make sense for missing texture files to cause the entire load to fail - for example, in a game engine, the textures may be in another folder that the user will assign later.