### PR TITLE
Fix reflection verification

### DIFF
--- a/src/SharpGLTF.Core/Reflection/FieldInfo.cs
+++ b/src/SharpGLTF.Core/Reflection/FieldInfo.cs
@@ -28,7 +28,7 @@ namespace SharpGLTF.Reflection
             if (path.Contains("/extras/", StringComparison.Ordinal)) return;
 
             var backingField = From(reflectionObject, path);
-            if (!backingField.IsEmpty) throw new ArgumentException($"{path} not found in the current model, add objects before animations, or disable verification.", nameof(path));
+            if (backingField.IsEmpty) throw new ArgumentException($"{path} not found in the current model, add objects before animations, or disable verification.", nameof(path));
         }
 
         #endregion


### PR DESCRIPTION
Creating an animation with KHR_animation_pointer, using Animation.CreateMaterialPropertyChannel or Animation.DangerousCreatePointerChannel, incorrectly throws an exception when the animation points to an existing property.